### PR TITLE
feat: re-export gc_arena.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+pub use gc_arena;
+
 pub mod any;
 pub mod callback;
 pub mod closure;


### PR DESCRIPTION
Hey! How do you feel about re-exporting `gc_arena`. I've needed to use a couple of it's types such as `Mutation` and the `Collect` trait, but when adding piccolo as a git dependency is trickier to make sure I have the same version of `gc_arena`, and I think it'd be nice not to have to worry about adding it to your Cargo.toml and making sure the versions match under normal circumstances.

Not sure if we should worry about the `gc_arena` derive macro or not.